### PR TITLE
removed Gutenberg plugin requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 # WordPress Gutenberg Blocks for NHS Theme
 
 This repository houses the native Gutenberg blocks for the Nightingale WordPress theme from NHS Leadership Academy. 
-This is a standalone plugin, but is intended to be used in concert with the Nightingale 2.0 theme. The plugin and theme together complete the WordPress deployment of the NHSUK Frontend design.
+This is a standalone plugin, but is intended to be used in concert with the [Nightingale](https://wordpress.org/themes/nightingale) theme. The plugin and theme together complete the WordPress deployment of the NHSUK Frontend design.
 
 ## Requirements
-This plugin requires minimum Wordpress 5.0 and Gutenberg 7.4 - the Gutenberg version is a very important requirement!
- If you already have the Gutenberg plugin, please ensure it is updated _before_ installing the plugin. If you don't 
- already have the Gutenberg plugin, we recommend you install that first.
+This plugin requires minimum Wordpress 5.0 
+
+If you are running the Gutenberg plugin as a separate entity (Gutenberg is built in to the core of WordPress - this
+ ONLY applies if you also have the plugin) then the NHSBlocks plugin may have some unexpected behaviour. The
+  NHSBlocks plugin is built to use the core version of Gutenberg included in WordPress.
  
  Whilst designed for the Nightingale WordPress theme, this plugin is a standalone and has its own css included, so 
- can be included to any WordPress site meeting the minimum requirements above.
+ can be included to any WordPress site meeting the minimum requirements above. If you ARE running the Nightingale
+  theme, the plugin stylesheets will be supressed and the the theme stylesheet will cover everyting so there will be
+   no duplication of css.
 
 ## Deployment Instructions
 Download the `nhsblocks.zip` from this repository. Install this to your wordpress via admin > plugins > add new > upload. Go to your wordpress admin, 
@@ -31,21 +35,3 @@ This plugin was written by Tony Blacker, NHS Leadership Academy Digital Delivery
 provided by [Morten Rand-Hendriksen](https://mor10.com/) and extended out to match the [NHSUK Frontend library 
 components](https://nhsuk.github.io/nhsuk-frontend/components) 
 
-## Progress
- - [x] Add in buttons
- - [x] Button variations (standard green, grey [secondary] and white [reverse])
- - [x] Add in Reveal
- - [x] Reveal variations (Expander)
- - [x] Care Cards
- - [x] Care Card Variations (non urgent [blue header], urgent [red header], immediate [red header, black body])
- - [x] Do / Dont List
- - [x] Panel
- - [x] Panel variations (standard [white], with label [white with blue masthead], grey)
- - [x] Testimonial / Quote
- - [x] Testimonial variant (standard [white background, blue left hand border], inverted [blue background, white left
-  hand border] - inverted is non standard NHSUK Frontend component)
- - [x] Promo panel
- - [x] Promo panel variants (with and without image, with and without link)
- - [x] Dashboard element (non NHSUK frontend component)
- - [x] Latest News - this has been moved to be a part of the theme as it is a theme function
- - [x] Grouped Columns (one-third, one-qaurter, two-thirds, one-half, full to make full rows)

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
   "repositories":[{"type":"composer","url":"https://wpackagist.org"}],
   "type": "wordpress-plugin",
   "require": {
-    "composer/installers": "^1.3",
-    "wpackagist-plugin/gutenberg":"^7.9.1"
+    "composer/installers": "^1.3"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9a62a9df4bdd8afe51d6a30c88272ead",
+    "content-hash": "44fbb71a0538967e3cf5320ef2bf0ec9",
     "packages": [
         {
             "name": "composer/installers",
@@ -132,24 +132,6 @@
                 "zikula"
             ],
             "time": "2020-04-07T06:57:05+00:00"
-        },
-        {
-            "name": "wpackagist-plugin/gutenberg",
-            "version": "7.9.1",
-            "source": {
-                "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/gutenberg/",
-                "reference": "tags/7.9.1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/gutenberg.7.9.1.zip"
-            },
-            "require": {
-                "composer/installers": "~1.0"
-            },
-            "type": "wordpress-plugin",
-            "homepage": "https://wordpress.org/plugins/gutenberg/"
         }
     ],
     "packages-dev": [],

--- a/nhsblocks.php
+++ b/nhsblocks.php
@@ -272,25 +272,6 @@ function nhsblocks_enqueue_style() {
 
 add_action( 'wp_enqueue_scripts', 'nhsblocks_enqueue_style' );
 
-/**
- * Checks if the Gutenberg plugin is activated
- *
- * If the Gutenberg plugin is not active, then don't allow the
- * activation of this plugin.
- *
- * @since 1.0.0
- */
-function nhsblocks_activate() {
-	if ( current_user_can( 'activate_plugins' ) && ! is_plugin_active( 'gutenberg/gutenberg.php' ) ) {
-		// Deactivate the plugin.
-		deactivate_plugins( plugin_basename( __FILE__ ) );
-		// Throw an error in the WordPress admin console.
-		$error_message = '<p style="font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\',Roboto,Oxygen-Sans,Ubuntu,Cantarell,\'Helvetica Neue\',sans-serif;font-size: 13px;line-height: 1.5;color:#444;">' . esc_html__( 'This plugin requires ', 'nhsblocks' ) . '<a href="' . esc_url( 'https://en-gb.wordpress.org/plugins/gutenberg/' ) . '">Gutenberg</a>' . esc_html__( ' plugin to be installed and active.', 'nhsblocks' ) . '</p>';
-		die( $error_message ); // WPCS: XSS ok.
-	}
-}
-
-register_activation_hook( __FILE__, 'nhsblocks_activate' );
 
 function nhsblocks_hero_footer() {
 	echo "<script>

--- a/readme.txt
+++ b/readme.txt
@@ -24,7 +24,8 @@ This plugin requires Gutenberg 7.9.1 (as a standalone plugin) to be installed an
 
 This section describes how to install the plugin and get it working.
 
-1. This plugin requires that the Gutenberg plugin (running as a plugin) is already installed and active on your site to get the latest developments and techniques available.
+1. This plugin uses the core version of Gutenberg included in WordPress 5.2 and higher. If you also run the Gutenberg
+plugin, you may encounter issues.
 2. Upload the plugin files to the `/wp-content/plugins/plugin-name` directory, or install the plugin through the WordPress plugins screen directly.
 3. Activate the plugin through the 'Plugins' screen in WordPress
 4. Navigate to edit or create any page or post.
@@ -49,6 +50,15 @@ This plugin has been built specifically for use in the NHS, but it is open sourc
 10. Hero - a full screen width block, with optional single colour or image background and optional block of text to anchor the page and set clear purpose
 
 == Changelog ==
+
+= 1.1.5 =
+ * visually hidden messages modified on care cards so status is reflected to screen readers
+ * removed php7.4 declaration types for backwards compatability
+ * updated dependencies in composer
+ * Removed requirement for separate Gutenberg plugin - instead use core WP version of Gutenberg. If you currently have
+ the Gutenberg plugin purely for the NHSBlocks plugin to work, we actively encourage you to remove the Gutenberg plugin
+ from your deployment to improve stability and performance.
+ *
 
 = 1.1.4 =
 * Removed a lot of excess styling in the css


### PR DESCRIPTION
Taken Gutenberg out of composer, removed activation check and updated readme files to reflect new install routine and to try and encourage users who DO have Gutenberg plugin installed to take it out.