### PR TITLE
Search field tweak

### DIFF
--- a/assets/scss/style_variations.scss
+++ b/assets/scss/style_variations.scss
@@ -97,12 +97,6 @@
   }
 }
 
-.nhsuk-header__search-wrap {
-  input[type="text"] {
-    border: 1px solid $color_nhsuk-grey-3;
-  }
-}
-
 /* Hero fix so it works on all templates */
 .wp-block-nhsblocks-heroblock {
   left: 50%;


### PR DESCRIPTION
Remove border of search field in NHS Nightingale.

This is the same fix that was included in [PR 336](https://github.com/NHSLeadership/nightingale-2-0/pull/336) for Nightingale:
https://github.com/NHSLeadership/nightingale-2-0/pull/336/commits/c98bbbfdcd4c57377c4ed9d86378ceb430320017