### PR TITLE
removed dequeue from admin styling to simplify theme loading

### DIFF
--- a/nhsblocks.php
+++ b/nhsblocks.php
@@ -243,10 +243,7 @@ function nhsblocks_block_classes( $attributes ) {
  * Queues up the gutenberg editor style
  */
 function nhsblocks_gutenberg_editor_styles() {
-	$theme = wp_get_theme(); // gets the current theme
-	if ( 'Nightingale' !== $theme->name ) {
 		wp_enqueue_style( 'nhsl-block-editor-styles', plugins_url( 'style-gutenburg.css', __FILE__ ), false, '1.1', 'all' );
-	}
 }
 
 add_action( 'enqueue_block_editor_assets', 'nhsblocks_gutenberg_editor_styles' ); // Pulls the enqueued file in to standard wp process.


### PR DESCRIPTION
Matches PR in Nightingale theme -https://github.com/NHSLeadership/nightingale-2-0/pull/399.

Effectively, removing the dequeue from nhsblocks for admin styling so that the plugin loads its own stylesheet in the editor. This avoids duplication of work, simplifies the admin css and ensures a better editor experience.

This does mean that when the next versions of Nightingale and NHSblocks are released, there will need to be a note explaining the requirement to update both at the same time to avoid editor bugs.